### PR TITLE
classes with only static methods should have a private constructor

### DIFF
--- a/src/main/java/com/wildbit/java/postmark/Postmark.java
+++ b/src/main/java/com/wildbit/java/postmark/Postmark.java
@@ -13,6 +13,9 @@ import java.util.Properties;
  */
 public class Postmark {
 
+    private Postmark() {
+    }
+    
     /**
      * Base Postmark APP Constants
      */


### PR DESCRIPTION
Still, the question is why all the static is needed. It's usually a better idea to make this class non-static. However, if there are reasons, please add a private constructor so accidents are avoided.