### PR TITLE
Moved to more abstract Map classes for arguments in Message classes

### DIFF
--- a/src/main/java/com/wildbit/java/postmark/client/data/model/message/Message.java
+++ b/src/main/java/com/wildbit/java/postmark/client/data/model/message/Message.java
@@ -1,8 +1,7 @@
 package com.wildbit.java.postmark.client.data.model.message;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.Map;
 
 /**
  * Postmark email message object
@@ -23,7 +22,7 @@ public class Message extends BaseMessage {
 
     private Boolean trackOpens;
     private String trackLinks;
-    private HashMap<String, String> metadata;
+    private Map<String, String> metadata;
 
     public Message() {
         super();
@@ -53,13 +52,13 @@ public class Message extends BaseMessage {
 
     public void setTrackLinks(TRACK_LINKS trackLinks) { this.trackLinks = trackLinks.value; }
 
-    public HashMap<String, String> getMetadata() { return metadata; }
+    public Map<String, String> getMetadata() { return metadata; }
 
-    public void setMetadata(HashMap<String, String> metadata) { this.metadata = metadata; }
+    public void setMetadata(Map<String, String> metadata) { this.metadata = metadata; }
 
     public void addMetadata(String key, String value) {
         if (metadata == null) {
-            metadata = new HashMap<>();
+            metadata = new HashMap<String, String>();
         }
         metadata.put(key,value);
     }

--- a/src/main/java/com/wildbit/java/postmark/client/data/model/messages/OutboundMessage.java
+++ b/src/main/java/com/wildbit/java/postmark/client/data/model/messages/OutboundMessage.java
@@ -1,7 +1,7 @@
 package com.wildbit.java.postmark.client.data.model.messages;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Date;
 
 /**
@@ -22,7 +22,7 @@ public class OutboundMessage {
     private String status;
     private Boolean trackOpens;
     private String trackLinks;
-    private HashMap<String, String> metadata;
+    private Map<String, String> metadata;
 
     // GETTERS AND SETTERS
 
@@ -130,8 +130,8 @@ public class OutboundMessage {
         this.trackLinks = trackLinks;
     }
 
-    public HashMap<String, String> getMetadata() { return metadata; }
+    public Map<String, String> getMetadata() { return metadata; }
 
-    public void setMetadata(HashMap<String, String> metadata) { this.metadata = metadata; }
+    public void setMetadata(Map<String, String> metadata) { this.metadata = metadata; }
 
 }

--- a/src/main/java/com/wildbit/java/postmark/client/data/model/templates/TemplatedMessage.java
+++ b/src/main/java/com/wildbit/java/postmark/client/data/model/templates/TemplatedMessage.java
@@ -1,5 +1,6 @@
 package com.wildbit.java.postmark.client.data.model.templates;
 
+import java.util.Map;
 import java.util.HashMap;
 
 /**
@@ -21,7 +22,7 @@ public class TemplatedMessage extends BaseTemplatedMessage {
 
     private Boolean trackOpens;
     private String trackLinks;
-    private HashMap<String, String> metadata;
+    private Map<String, String> metadata;
 
     public TemplatedMessage() {
         super();
@@ -45,9 +46,9 @@ public class TemplatedMessage extends BaseTemplatedMessage {
 
     public void setTrackLinks(String trackLinks) { this.trackLinks = trackLinks; }
 
-    public HashMap<String, String> getMetadata() { return metadata; }
+    public Map<String, String> getMetadata() { return metadata; }
 
-    public void setMetadata(HashMap<String, String> metadata) { this.metadata = metadata; }
+    public void setMetadata(Map<String, String> metadata) { this.metadata = metadata; }
 
     public void addMetadata(String key, String value) {
         if (metadata == null) {

--- a/src/main/java/com/wildbit/java/postmark/client/data/model/webhooks/BounceWebhook.java
+++ b/src/main/java/com/wildbit/java/postmark/client/data/model/webhooks/BounceWebhook.java
@@ -3,7 +3,6 @@ package com.wildbit.java.postmark.client.data.model.webhooks;
 import com.wildbit.java.postmark.client.data.model.bounces.Bounce;
 
 import java.util.HashMap;
-import java.util.List;
 
 /**
  * Bounce webhook object.

--- a/src/test/java/integration/TemplatedMessageTest.java
+++ b/src/test/java/integration/TemplatedMessageTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 
 public class TemplatedMessageTest extends BaseTest {
 
@@ -32,14 +33,14 @@ public class TemplatedMessageTest extends BaseTest {
     void metadata() throws PostmarkException, IOException {
         TemplatedMessage message = new TemplatedMessage("from@example.com", "to@example.com", 1);
 
-        HashMap<String,String> metadata = new HashMap<String, String>();
+        Map<String,String> metadata = new HashMap<String, String>();
         metadata.put("test1","value1");
 
         message.setMetadata(metadata);
         message.addMetadata("test2","value2");
         message.addMetadata("test3","value3");
 
-        HashMap<String,String> templatedMessageMetadata = message.getMetadata();
+        Map<String,String> templatedMessageMetadata = message.getMetadata();
         assertEquals(templatedMessageMetadata.get("test1"), "value1");
         assertEquals(templatedMessageMetadata.get("test2"), "value2");
         assertEquals(templatedMessageMetadata.get("test3"), "value3");


### PR DESCRIPTION
Migrated to using the base `java.util.Map` as arguments / return types for Message classes to improve support for other JVM languages where HashMap is not the preferred Map.