### PR TITLE
DeliveryType property added to Server

### DIFF
--- a/src/main/java/com/wildbit/java/postmark/client/data/model/server/Server.java
+++ b/src/main/java/com/wildbit/java/postmark/client/data/model/server/Server.java
@@ -28,6 +28,7 @@ public class Server {
     private String inboundHash;
     private String inboundSpamThreshold;
     private String enableSmtpApiErrorHooks;
+    private String deliveryType;
 
     // SETTERS AND GETTERS
 
@@ -194,4 +195,12 @@ public class Server {
     public void setInboundSpamThreshold(String inboundSpamThreshold) {
         this.inboundSpamThreshold = inboundSpamThreshold;
     }
+    
+    public String getDeliveryType() {
+		return deliveryType;
+	}
+
+	public void setDeliveryType(String deliveryType) {
+		this.deliveryType = deliveryType;
+	}
 }


### PR DESCRIPTION
Added new property DeliveryType (String) to Server.java 

Description in https://postmarkapp.com/developer/api/servers-api -> Specifies the type of environment for your server. Possible options: Live Sandbox. Defaults to Live if not specified. This cannot be changed after the server has been created.

