### PR TITLE
Use List interface instead of ArrayList for return types and method parameters

### DIFF
--- a/src/main/java/com/wildbit/java/postmark/client/ApiClient.java
+++ b/src/main/java/com/wildbit/java/postmark/client/ApiClient.java
@@ -26,8 +26,8 @@ import com.wildbit.java.postmark.client.exception.PostmarkException;
 
 import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Class that handles on very top level all API requests. All Postmark public endpoints which
@@ -68,9 +68,9 @@ public class ApiClient extends BaseApiClient {
         return dataHandler.fromJson(response, MessageResponse.class);
     }
 
-    public ArrayList<MessageResponse> deliverMessage(ArrayList<Message> data) throws PostmarkException, IOException {
+    public List<MessageResponse> deliverMessage(List<Message> data) throws PostmarkException, IOException {
         String response = execute(HttpClient.REQUEST_TYPES.POST, getEndpointUrl(sendingEndpoint + "batch"), data);
-        return dataHandler.fromJson(response, new TypeReference<ArrayList<MessageResponse>>() {});
+        return dataHandler.fromJson(response, new TypeReference<List<MessageResponse>>() {});
     }
 
     /*
@@ -168,19 +168,19 @@ public class ApiClient extends BaseApiClient {
         return dataHandler.fromJson(response, MessageResponse.class);
     }
 
-    public ArrayList<MessageResponse> deliverMessageWithTemplate(ArrayList<TemplatedMessage> data) throws PostmarkException, IOException {
+    public List<MessageResponse> deliverMessageWithTemplate(List<TemplatedMessage> data) throws PostmarkException, IOException {
         /*
           When sending array of emails with templates, additional top level field is used called "Messages".
           This introduces unnecessary difference between batch and batchWithTemplates endpoint in data model.
           To keep it simple, this additional level is added before executing batch send.
          */
-        HashMap<String, ArrayList> dataToSend = new HashMap<>();
+        HashMap<String, List> dataToSend = new HashMap<>();
         dataToSend.put("Messages", data);
 
         for(TemplatedMessage templateMessage:data) { setTemplateModelToObject(templateMessage); }
 
         String response = execute(HttpClient.REQUEST_TYPES.POST, getEndpointUrl(sendingEndpoint + "batchWithTemplates"), dataToSend);
-        return dataHandler.fromJson(response, new TypeReference<ArrayList<MessageResponse>>() {});
+        return dataHandler.fromJson(response, new TypeReference<List<MessageResponse>>() {});
     }
 
     private void setTemplateModelToObject(TemplatedMessage data) throws IOException {

--- a/src/test/java/unit/data/BounceTest.java
+++ b/src/test/java/unit/data/BounceTest.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -37,7 +38,7 @@ public class BounceTest extends BaseTest {
         Bounce bounce = new Bounce();
         bounce.setId(1L);
         bounce.setContent("test");
-        ArrayList<Bounce> data = new ArrayList<>();
+        List<Bounce> data = new ArrayList<>();
         data.add(bounce);
 
         Bounces bounces = new Bounces();

--- a/src/test/java/unit/data/MessageTest.java
+++ b/src/test/java/unit/data/MessageTest.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -85,7 +86,7 @@ public class MessageTest extends BaseTest {
     void singleMessageToRecipient() {
         Message message = new Message();
 
-        ArrayList<String> recipients = new ArrayList<>();
+        List<String> recipients = new ArrayList<>();
         recipients.add("igor@example.com");
 
         message.setTo(recipients);
@@ -97,7 +98,7 @@ public class MessageTest extends BaseTest {
 
         Message message = new Message();
 
-        ArrayList<String> recipients = new ArrayList<>();
+        List<String> recipients = new ArrayList<>();
         recipients.add("igor@example.com");
         recipients.add("john@example.com");
         recipients.add("chris@example.com");
@@ -126,7 +127,7 @@ public class MessageTest extends BaseTest {
 
         Message message = new Message();
 
-        ArrayList<String> recipients = new ArrayList<>();
+        List<String> recipients = new ArrayList<>();
         recipients.add("igor@example.com");
         recipients.add("john@example.com");
         recipients.add("chris@example.com");
@@ -155,7 +156,7 @@ public class MessageTest extends BaseTest {
 
         Message message = new Message();
 
-        ArrayList<String> recipients = new ArrayList<>();
+        List<String> recipients = new ArrayList<>();
         recipients.add("igor@example.com");
         recipients.add("john@example.com");
         recipients.add("chris@example.com");


### PR DESCRIPTION
By using the List interface consumers of the API have more flexibility in how they interact with it.

Example when using this library with Kotlin:
With `ArrayList`
```Kotlin
val postmarkClient = Postmark.getApiClient(postmarkToken)
val messages = listOf(constructTemplateMessage(templateId, receiver, model)
postmarkClient.deliverMessageWithTemplate(messages as ArrayList<TemplatedMessage>)
```

With `List`
```Kotlin
val postmarkClient = Postmark.getApiClient(postmarkToken)
val messages = listOf(constructTemplateMessage(templateId, receiver, model)
postmarkClient.deliverMessageWithTemplate(messages)
```