### PR TITLE
Accept any List of messages to deliver

### DIFF
--- a/src/main/java/com/wildbit/java/postmark/client/ApiClient.java
+++ b/src/main/java/com/wildbit/java/postmark/client/ApiClient.java
@@ -28,6 +28,8 @@ import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Class that handles on very top level all API requests. All Postmark public endpoints which
@@ -68,7 +70,7 @@ public class ApiClient extends BaseApiClient {
         return dataHandler.fromJson(response, MessageResponse.class);
     }
 
-    public ArrayList<MessageResponse> deliverMessage(ArrayList<Message> data) throws PostmarkException, IOException {
+    public ArrayList<MessageResponse> deliverMessage(List<Message> data) throws PostmarkException, IOException {
         String response = execute(HttpClient.REQUEST_TYPES.POST, getEndpointUrl(sendingEndpoint + "batch"), data);
         return dataHandler.fromJson(response, new TypeReference<ArrayList<MessageResponse>>() {});
     }
@@ -168,13 +170,13 @@ public class ApiClient extends BaseApiClient {
         return dataHandler.fromJson(response, MessageResponse.class);
     }
 
-    public ArrayList<MessageResponse> deliverMessageWithTemplate(ArrayList<TemplatedMessage> data) throws PostmarkException, IOException {
+    public ArrayList<MessageResponse> deliverMessageWithTemplate(List<TemplatedMessage> data) throws PostmarkException, IOException {
         /*
           When sending array of emails with templates, additional top level field is used called "Messages".
           This introduces unnecessary difference between batch and batchWithTemplates endpoint in data model.
           To keep it simple, this additional level is added before executing batch send.
          */
-        HashMap<String, ArrayList> dataToSend = new HashMap<>();
+        Map<String, List<TemplatedMessage>> dataToSend = new HashMap<>();
         dataToSend.put("Messages", data);
 
         for(TemplatedMessage templateMessage:data) { setTemplateModelToObject(templateMessage); }


### PR DESCRIPTION
Current API accepts only `ArrayList`s for absolutely no reason.
This forces consumers to always wrap their message lists in a new `ArrayList` collection like so:
```java
List<Message> messages;
...
client.deliverMessage(new ArrayList<>(messages));
```

Accept generic `List`s instead.